### PR TITLE
Add info logging output.

### DIFF
--- a/pwvlt-cli/src/config.rs
+++ b/pwvlt-cli/src/config.rs
@@ -21,22 +21,29 @@ strict = true
 pub fn load_config() -> Result<Config, Error> {
     let home = home::home_dir().ok_or(Error::HomeNotFound)?;
     // config will be loaded from ~/.config/pwvlt/config.toml
-    let config_folder = home.join(".config").join("pwvlt");
-    if !config_folder.exists() {
-        create_dir_all(&config_folder)?;
+    let config_dir = home.join(".config").join("pwvlt");
+    if !config_dir.exists() {
+        log::info!("Creating {}", config_dir.display());
+        create_dir_all(&config_dir)?;
     }
-    let config_file = config_folder.join("config.toml");
+    let config_file = config_dir.join("config.toml");
     if !config_file.exists() {
-        write!(File::create(&config_file)?, "{}", DEFAULT_CONFIG)?;
+        log::info!("Writing default config to: {}", config_file.display());
+        let mut config = File::create(&config_file)?;
+        write!(config, "{}", DEFAULT_CONFIG)?;
     }
-    toml::from_str(&read_to_string(config_file)?).map_err(Error::from)
+    log::info!("Loading toml config into memory");
+    let toml_config = read_to_string(config_file)?;
+    toml::from_str(&toml_config).map_err(Error::from)
 }
 
 pub fn write_config(config: &Config) -> Result<(), Error> {
     let home = home::home_dir().ok_or(Error::HomeNotFound)?;
+    log::info!("Writing pwvlt config.");
     write!(
         File::create(home.join(".config").join("pwvlt").join("config.toml"))?,
         "{}",
         toml::to_string(config)?
-    ).map_err(Error::from)
+    )
+    .map_err(Error::from)
 }

--- a/pwvlt-cli/src/error.rs
+++ b/pwvlt-cli/src/error.rs
@@ -6,7 +6,7 @@ pub enum Error {
     Io(std::io::Error),
     TomlDeserialize(toml::de::Error),
     TomlSerialize(toml::ser::Error),
-    PassStore(PassStoreError)
+    PassStore(PassStoreError),
 }
 
 impl From<Box<dyn std::error::Error>> for Error {

--- a/pwvlt/src/error.rs
+++ b/pwvlt/src/error.rs
@@ -5,7 +5,6 @@ use std::error::Error;
 use std::fmt;
 use std::io::Error as IoError;
 
-
 #[derive(derive_more::From, Debug)]
 pub enum PassStoreError {
     PasswordNotFound,

--- a/pwvlt/src/keyring_store.rs
+++ b/pwvlt/src/keyring_store.rs
@@ -34,7 +34,7 @@ impl PassStore for KeyringStore {
             PassStoreError::KeyringError(err) => format!("{}", err),
             _ => unreachable!("A KeyringStore shouldn't generate a {} error.", err),
         };
-        println!("{}", msg);
+        log::warn!("{}", msg);
     }
 
     fn name(&self) -> &'static str {

--- a/pwvlt/src/nitrokey_store.rs
+++ b/pwvlt/src/nitrokey_store.rs
@@ -104,7 +104,7 @@ impl PassStore for NitrokeyStore {
             },
             err => unreachable!("A NitrokeyKeyStore shouldn't generate a {} error.", err),
         };
-        println!("{}", message);
+        log::warn!("{}", message);
     }
 
     fn name(&self) -> &'static str {

--- a/pwvlt/src/util.rs
+++ b/pwvlt/src/util.rs
@@ -17,6 +17,7 @@ pub fn random_password(config: &config::Password) -> Result<String, PassStoreErr
         symbols: config.symbols,
         strict: config.strict,
     };
+    log::info!("Generating random password.");
     pg.generate_one()
         .map_err(|e| PassStoreError::PasswordGenerationError(e.into()))
 }


### PR DESCRIPTION
Users can now trace the execution of the pwvlt crate with `-v`.